### PR TITLE
Mobile responsive issue fix

### DIFF
--- a/src/ng-chat/assets/ng-chat.component.default.css
+++ b/src/ng-chat/assets/ng-chat.component.default.css
@@ -21,7 +21,7 @@
 #ng-chat-people
 {
     position: relative;
-    width: 240px;
+    width: 300px;
     height:360px;
     border-width: 1px;
     border-style: solid;

--- a/src/ng-chat/assets/ng-chat.component.default.css
+++ b/src/ng-chat/assets/ng-chat.component.default.css
@@ -21,11 +21,11 @@
 #ng-chat-people
 {
     position: relative;
-    width: 100%;
-    height:300px;
+    width: 240px;
+    height: 360px;
     border-width: 1px;
     border-style: solid;
-    margin-right:0;
+    margin-right: 20px;
     box-shadow: 0 4px 8px rgba(0,0,0,.25);
     border-bottom:0;
 }
@@ -212,14 +212,15 @@
 }
 .ng-chat-window
 {
-    right:260px;
-    height:360px;
-    z-index:999;
-    bottom:0;
-    width:300px;
+    right: 260px;
+    height: 360px;
+    z-index: 999;
+    bottom: 0;
+    position: fixed;
+    width: 300px;
     border-width: 1px;
     border-style: solid;
-    border-bottom:0;
+    border-bottom: 0;
     box-shadow: 0 4px 8px rgba(0,0,0,.25);
 }
 .ng-chat-window-collapsed
@@ -415,4 +416,18 @@
 {
     float: right;
     margin-right: 5px;
+}
+
+@media only screen and (max-width: 768px) { 
+    #ng-chat-people
+    {
+        width: 100%!important;
+        height: 360px!important;
+        margin-right: 0!important;
+    }
+    
+    .ng-chat-window
+    {
+        position: initial!important;
+    }
 }

--- a/src/ng-chat/assets/ng-chat.component.default.css
+++ b/src/ng-chat/assets/ng-chat.component.default.css
@@ -22,7 +22,7 @@
 {
     position: relative;
     width: 240px;
-    height: 360px;
+    height:360px;
     border-width: 1px;
     border-style: solid;
     margin-right: 20px;
@@ -216,8 +216,8 @@
     height: 360px;
     z-index: 999;
     bottom: 0;
-    position: fixed;
     width: 300px;
+    position: fixed;
     border-width: 1px;
     border-style: solid;
     border-bottom: 0;
@@ -419,15 +419,15 @@
 }
 
 @media only screen and (max-width: 768px) { 
-    #ng-chat-people
-    {
-        width: 100%!important;
-        height: 360px!important;
-        margin-right: 0!important;
-    }
-    
-    .ng-chat-window
-    {
-        position: initial!important;
-    }
-}
+     #ng-chat-people
+     {
+         width: 270px;
+         height: 360px;
+         margin-right: 0;
+     }
+
+      .ng-chat-window
+     {
+         position: initial;
+     }
+ }

--- a/src/ng-chat/assets/ng-chat.component.default.css
+++ b/src/ng-chat/assets/ng-chat.component.default.css
@@ -21,11 +21,11 @@
 #ng-chat-people
 {
     position: relative;
-    width: 240px;
-    height:360px;
+    width: 100%;
+    height:300px;
     border-width: 1px;
     border-style: solid;
-    margin-right:20px;
+    margin-right:0;
     box-shadow: 0 4px 8px rgba(0,0,0,.25);
     border-bottom:0;
 }
@@ -216,7 +216,6 @@
     height:360px;
     z-index:999;
     bottom:0;
-    position: fixed;
     width:300px;
     border-width: 1px;
     border-style: solid;

--- a/src/ng-chat/ng-chat.component.ts
+++ b/src/ng-chat/ng-chat.component.ts
@@ -133,7 +133,10 @@ export class NgChat implements OnInit, IChatController {
 
     @Input()
     public showMessageDate: boolean = true;
-
+    
+    @Input()
+    public isViewportOnMobileEnabled: boolean = false;
+     
     @Output()
     public onParticipantClicked: EventEmitter<IChatParticipant> = new EventEmitter<IChatParticipant>();
 
@@ -218,10 +221,7 @@ export class NgChat implements OnInit, IChatController {
     
     // Set to true if there is no space to display at least one chat window and 'hideFriendsListOnUnsupportedViewport' is true
     public unsupportedViewport: boolean = false;
-    
-    // Set to true if you want to show chat components in mobile devices
-    public isViewportOnMobileEnabled: boolean = false;
-    
+
     // File upload state
     public fileUploadersInUse: string[] = []; // Id bucket of uploaders in use
     public fileUploadAdapter: IFileUploadAdapter;
@@ -514,15 +514,14 @@ export class NgChat implements OnInit, IChatController {
             }
 
             this.windows.unshift(newChatWindow);
-            
-            // Is there enough space left in the view port ? but should show in mobile if option is enabled
+
+            // Is there enough space left in the view port ? but should be displayed in mobile if option is enabled
             if (!this.isViewportOnMobileEnabled) {
-              if (this.windows.length * this.windowSizeFactor >= this.viewPortTotalArea - (!this.hideFriendsList ? this.friendsListWidth : 0))
-              {                
-                  this.windows.pop();
-              }
+                if (this.windows.length * this.windowSizeFactor >= this.viewPortTotalArea - (!this.hideFriendsList ? this.friendsListWidth : 0)) {
+                    this.windows.pop();
+                }
             }
-            
+
             this.updateWindowsState(this.windows);
             
             if (focusOnNewWindow && !collapseWindow) 

--- a/src/ng-chat/ng-chat.component.ts
+++ b/src/ng-chat/ng-chat.component.ts
@@ -218,7 +218,10 @@ export class NgChat implements OnInit, IChatController {
     
     // Set to true if there is no space to display at least one chat window and 'hideFriendsListOnUnsupportedViewport' is true
     public unsupportedViewport: boolean = false;
-
+    
+    // Set to true if you want to show chat components in mobile devices
+    public isViewportOnMobileEnabled: boolean = false;
+    
     // File upload state
     public fileUploadersInUse: string[] = []; // Id bucket of uploaders in use
     public fileUploadAdapter: IFileUploadAdapter;
@@ -256,10 +259,8 @@ export class NgChat implements OnInit, IChatController {
 
         this.updateWindowsState(this.windows);
 
-        // Viewport should have space for at least one chat window.
-        // this.unsupportedViewport = this.hideFriendsListOnUnsupportedViewport && maxSupportedOpenedWindows < 1;
-        // temporarily comment above line for making viewport to be available in mobile devices
-        this.unsupportedViewport = false;
+        // Viewport should have space for at least one chat window but should show in mobile if option is enabled.
+        this.unsupportedViewport = this.isViewportOnMobileEnabled? false : this.hideFriendsListOnUnsupportedViewport && maxSupportedOpenedWindows < 1;
     }
 
     // Initializes the chat plugin and the messaging adapter
@@ -514,12 +515,13 @@ export class NgChat implements OnInit, IChatController {
 
             this.windows.unshift(newChatWindow);
             
-            // Comment this line for now because it is hidden in mobile devices
-            // Is there enough space left in the view port ?
-            // if (this.windows.length * this.windowSizeFactor >= this.viewPortTotalArea - (!this.hideFriendsList ? this.friendsListWidth : 0))
-            // {                
-            //     this.windows.pop();
-            // }
+            // Is there enough space left in the view port ? but should show in mobile if option is enabled
+            if (!this.isViewportOnMobileEnabled) {
+              if (this.windows.length * this.windowSizeFactor >= this.viewPortTotalArea - (!this.hideFriendsList ? this.friendsListWidth : 0))
+              {                
+                  this.windows.pop();
+              }
+            }
             
             this.updateWindowsState(this.windows);
             

--- a/src/ng-chat/ng-chat.component.ts
+++ b/src/ng-chat/ng-chat.component.ts
@@ -257,7 +257,9 @@ export class NgChat implements OnInit, IChatController {
         this.updateWindowsState(this.windows);
 
         // Viewport should have space for at least one chat window.
-        this.unsupportedViewport = this.hideFriendsListOnUnsupportedViewport && maxSupportedOpenedWindows < 1;
+        // this.unsupportedViewport = this.hideFriendsListOnUnsupportedViewport && maxSupportedOpenedWindows < 1;
+        // temporarily comment above line for making viewport to be available in mobile devices
+        this.unsupportedViewport = false;
     }
 
     // Initializes the chat plugin and the messaging adapter
@@ -511,13 +513,14 @@ export class NgChat implements OnInit, IChatController {
             }
 
             this.windows.unshift(newChatWindow);
-
+            
+            // Comment this line for now because it is hidden in mobile devices
             // Is there enough space left in the view port ?
-            if (this.windows.length * this.windowSizeFactor >= this.viewPortTotalArea - (!this.hideFriendsList ? this.friendsListWidth : 0))
-            {                
-                this.windows.pop();
-            }
-
+            // if (this.windows.length * this.windowSizeFactor >= this.viewPortTotalArea - (!this.hideFriendsList ? this.friendsListWidth : 0))
+            // {                
+            //     this.windows.pop();
+            // }
+            
             this.updateWindowsState(this.windows);
             
             if (focusOnNewWindow && !collapseWindow) 

--- a/src/spec/ng-chat.component.spec.ts
+++ b/src/spec/ng-chat.component.spec.ts
@@ -97,7 +97,11 @@ describe('NgChat', () => {
     it('Persistent windows state must be enabled by default', () => {
         expect(subject.persistWindowsState).toBeTruthy();
     });
-
+    
+    it('Is viewport mobile case state must be disabled by default', () => {
+        expect(subject.isViewportOnMobileEnabled).toBeFalsy();
+    });
+    
     it('isCollapsed must be disabled by default', () => {
         expect(subject.isCollapsed).toBeFalsy();
     });


### PR DESCRIPTION
Ng-Chat isn't displayed in mobile devices. 

As long as, most of the users are using mobile devices, we should display them in mobile devices.

:1:  Chat components are hidden in mobile devices. So fixed it that it is displayed in mobile devices.
:2: Changed components sizes so that they have same width.
:3: They can be switched using collapse functionality.

Regards

Andy Lee